### PR TITLE
Updated application.properties to resolve being able to receive large…

### DIFF
--- a/FHIR/src/main/resources/application.properties
+++ b/FHIR/src/main/resources/application.properties
@@ -10,7 +10,11 @@ management.endpoint.jolokia.enabled=true
 # Must be unique and defined otherwise defaults to 8080
 # used for any Fuse SpringBoot developed assets
 # Server - Internal
+management.port=9961
 server.port=9961
+server.max-http-header-size=200000
+server.address=0.0.0.0
+management.address=0.0.0.0
 # Kafka
 idaas.kafkaBrokers=localhost:9092
 idaas.kicTopicName=opsmgmt_platformtransactions

--- a/KIC/src/main/resources/application.properties
+++ b/KIC/src/main/resources/application.properties
@@ -10,7 +10,11 @@ management.endpoint.jolokia.enabled=true
 # Must be unique and defined otherwise defaults to 8080
 # used for any Fuse SpringBoot developed assets
 # Server - Internal
+management.port=9962
 server.port=9962
+server.max-http-header-size=200000
+server.address=0.0.0.0
+management.address=0.0.0.0
 # Kafka
 idaas.kafkaBrokers=localhost:9092
 # Connectivity Attributes

--- a/ThirdParty/src/main/resources/application.properties
+++ b/ThirdParty/src/main/resources/application.properties
@@ -10,7 +10,11 @@ management.endpoint.jolokia.enabled=true
 # Must be unique and defined otherwise defaults to 8080
 # used for any Fuse SpringBoot developed assets
 # Server - Internal
+management.port=9963
 server.port=9963
+server.max-http-header-size=200000
+server.address=0.0.0.0
+management.address=0.0.0.0
 # Kafka
 idaas.kafkaBrokers=localhost:9092
 # Connectivity Attributes


### PR DESCRIPTION
… messages, host address binding issues and inconsistency with server ports. Added management.port to match server.port, added server.max-http-header-size=200000 for large messages sent via http/https, and server.address=0.0.0.0

 management.address=0.0.0.0 to ensure host addresses are properly bound.